### PR TITLE
Add Fujifilm X-T3 camera

### DIFF
--- a/deploy/cameras.json
+++ b/deploy/cameras.json
@@ -217,6 +217,18 @@
     "tags": ["drone"]
   },
   {
+    "name": "Fujifilm X-T3",
+    "sensorSize": [23.5, 15.6],
+    "category": ["Still", "Movie"],
+    "description": "",
+    "sources": [
+      "https://fujifilm-x.com/global/products/cameras/x-t3/specifications/",
+      "https://en.wikipedia.org/wiki/Fujifilm_X-T3",
+      "https://www.digicamdb.com/specs/fujifilm_x-t3/"
+    ],
+    "tags": ["aps-c"]
+  },
+  {
     "name": "GoPro HERO Series",
     "sensorSize": [6.17, 4.55],
     "category": ["Mobile"],


### PR DESCRIPTION
Adding the Fujifilm X-T3 camera. All recent Fujifilm X-Trans sensor cameras share the same APS-C sensor size of 23.5mmx15.6mm. Adding the X-T3 here to start, but it should be the same for the X-T4, X-H2S, etc.