### PR TITLE
Added 4K UHD to Sony a7S III

### DIFF
--- a/deploy/cameras.json
+++ b/deploy/cameras.json
@@ -2787,6 +2787,10 @@
       {
         "format": "Open Gate",
         "size": [35.6, 23.8]
+      },
+      {
+        "format": "4K UHD",
+        "size": [35.6, 20.0]
       }
     ],
     "category": ["Still"],


### PR DESCRIPTION
Added 16:9 4K UHD to the Sony a7S III
I left the horizontal the same and scaled the vertical down accordingly. LMK if that's the proper way to do it.